### PR TITLE
Fix websockets error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests
-python-dateutil
-cryptography
-urllib3
-python-dotenv
-websockets
-datetime
+requests==2.32.3
+python-dateutil==2.9.0.post0
+cryptography==44.0.2
+urllib3==2.3.0
+python-dotenv==1.0.1
+websockets==14.1
+datetime==5.5


### PR DESCRIPTION
websockets 15 breaks the example code with the error below, but 14 works:

```
TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'additional_headers'
```

I froze the version numbers in requirements.txt